### PR TITLE
feat(ui): add card visuals and announce options

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This will start a development server (using Vite) and open the game in your brow
 - Click a card in your hand to play it.
 - Bots automatically choose a legal card to play.
 - Highest card in the lead suit wins each trick.
+- Cards are displayed with suit colors and card-like visuals.
+- Simple announce controls let you check for Belote, All Koz, or Without Koz.
 
 ## License
 

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,43 @@
+.app {
+  font-family: sans-serif;
+  text-align: center;
+}
+
+.controls {
+  margin-bottom: 1rem;
+}
+
+.hand {
+  margin-top: 1rem;
+}
+
+.card {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 50px;
+  height: 70px;
+  border: 1px solid #333;
+  border-radius: 4px;
+  margin: 0 4px;
+  font-size: 20px;
+  line-height: 1;
+  background-color: #fff;
+}
+
+.card.red {
+  color: #d00;
+}
+
+.card.black {
+  color: #000;
+}
+
+.trick {
+  margin-top: 1rem;
+}
+
+.announce {
+  margin-top: 0.5rem;
+  font-weight: bold;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import './App.css';
 
 const suits = ['♣', '♦', '♥', '♠'];
 const ranks = ['7', '8', '9', 'J', 'Q', 'K', '10', 'A'];
@@ -59,6 +60,9 @@ export default function App() {
   const [trick, setTrick] = useState([]); // {player, card}
   const [leadSuit, setLeadSuit] = useState(null);
   const [message, setMessage] = useState('');
+  const [announce, setAnnounce] = useState('');
+  const [trumpSuit, setTrumpSuit] = useState('♠');
+  const [announceMsg, setAnnounceMsg] = useState('');
 
   useEffect(() => {
     const deck = shuffle(createDeck());
@@ -106,23 +110,74 @@ export default function App() {
   const isPlayersTurn = currentPlayer === 0;
   const legal = legalMoves(playerHand, leadSuit);
 
+  const belote =
+    playerHand.some(c => c.rank === 'K' && c.suit === trumpSuit) &&
+    playerHand.some(c => c.rank === 'Q' && c.suit === trumpSuit);
+
+  useEffect(() => {
+    if (announce === 'belote') {
+      setAnnounceMsg(belote ? `Belote in ${trumpSuit}!` : `No belote in ${trumpSuit}.`);
+    } else if (announce === 'all_koz') {
+      setAnnounceMsg('All Koz (all trump)');
+    } else if (announce === 'without_koz') {
+      setAnnounceMsg('Without Koz (no trump)');
+    } else {
+      setAnnounceMsg('');
+    }
+  }, [announce, trumpSuit, belote]);
+
+  const suitColor = suit => (['♥', '♦'].includes(suit) ? 'red' : 'black');
+
   return (
-    <div>
+    <div className="app">
       <h1>Simple Belote</h1>
+      <div className="controls">
+        <label>
+          Announce:
+          <select value={announce} onChange={e => setAnnounce(e.target.value)}>
+            <option value="">--</option>
+            <option value="belote">Belote</option>
+            <option value="all_koz">All Koz</option>
+            <option value="without_koz">Without Koz</option>
+          </select>
+        </label>
+        {announce === 'belote' && (
+          <label>
+            {' '}
+            Trump:
+            <select value={trumpSuit} onChange={e => setTrumpSuit(e.target.value)}>
+              {suits.map(s => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+        {announceMsg && <div className="announce">{announceMsg}</div>}
+      </div>
       {message && <p>{message}</p>}
       <div className="trick">
         {trick.map(t => (
-          <div key={t.player}>P{t.player + 1}: {t.card.rank}{t.card.suit}</div>
+          <div key={t.player}>
+            P{t.player + 1}:{' '}
+            <span className={`card ${suitColor(t.card.suit)}`}>
+              {t.card.rank}
+              {t.card.suit}
+            </span>
+          </div>
         ))}
       </div>
       <div className="hand">
         {playerHand.map((card, i) => (
           <button
+            className={`card ${suitColor(card.suit)}`}
             key={i}
             disabled={!isPlayersTurn || !legal.some(c => c === card)}
             onClick={() => playCard(card)}
           >
-            {card.rank}{card.suit}
+            {card.rank}
+            {card.suit}
           </button>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- style cards with suit colors for a clearer hand and trick display
- add announce controls for Belote, All Koz, and Without Koz
- document UI improvements in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895d5015748832f9fcad6be96bbe11a